### PR TITLE
Adding docs for Forum Merge and Redirector

### DIFF
--- a/docs/addons/forummerge/index.html.md
+++ b/docs/addons/forummerge/index.html.md
@@ -1,0 +1,42 @@
+---
+title: Forum Merge
+layout: docs
+categories: ["Addons"]
+---
+
+## When to Use Forum Merge
+
+The ForumMerge plug-in should be used when you want to take one existing Vanilla forum instance and merge it into another existing Vanilla forum.  Core Vanilla data, in addition to some plug-in and addon data, will be carried over from the source into the destination forum and reconciled with existing records to avoid conflicts.
+
+## What Data is Merged
+
+The following Vanilla data will be considered during the merge process:
+
+* Attachments
+* Bookmarks
+* Categories
+* Comments
+* Conversations
+* Discussions
+* Roles
+* Users
+
+In addition, the following plug-ins have their data merged, if present:
+
+* Polls
+* Tagging
+
+## The Process of Merging Forums
+
+1. Ensure your source forum database is on the same server and accessible by the same database user configured for your destination forum.
+2. Install and enable the ForumMerge plug-in on the destination forum.  Enabling the plug-in may take several seconds to complete if the destination forum is large.  This is due to the addition of an OldID column across several tables.  It is also possible the plug-in cannot be enabled due to the size of some tables.  If this step fails, you should be presented with SQL commands you will need to run manually against the database before the plug-in can be successfully enabled.
+3. Visit the Merge page, listed under Import in the dashboard sidebar.
+4. Enter your source forum's database name and table prefix.  If you will be merging multiple forums, you can specify a "Legacy Slug" that will identify the records coming from the source separately from any subsequent merges with a different legacy slug.
+5. Click begin.  Cross your fingers.
+6. If the merge is successful, the page should appear to refresh, but there is currently no status message to confirm.
+7. If you'll be merging in another forum, you can visit /utility/mergereset to reset all existing OldID fields.
+
+## Notes
+
+1. Do not enable the Forum Merge plug-in on the source forum.  If it has been enabled in the past, you'll need to remove all OldID and OldCategoryID columns from the relevant tables prior to running the merge.  Failure to do so will cause a fatal SQL error during the merge, because the merge-specific columns (OldID, OldCategoryID) are being selected twice.
+2. If dumping the destination forum data into an existing forum install with ForumMerge enabled, you'll need to disable, then re-enable the ForumMerge plug-in or visit /utility/update to apply the necessary database table updates.  Failure to do so will cause a fatal SQL error, because the required columns (OldID, OldCategoryID) aren't present.

--- a/docs/addons/redirector/index.html.md
+++ b/docs/addons/redirector/index.html.md
@@ -1,0 +1,33 @@
+---
+title: Redirector
+layout: docs
+categories: ["Addons"]
+---
+
+## When to Use Redirector
+
+Redirector is a plug-in that traslates URLs from many popular forum platforms into Vanilla-friendly URLs.  If you're moving from one of the supported platforms, installing and enabling this plug-in will magically handle maintaining the previous platform's links, which can be of tremendous SEO value.
+
+## Supported Platforms
+
+1. IPB
+2. Jive
+3. phpBB
+4. punBB
+5. smf
+6. vBulletin
+7. xenforo
+
+## Usage
+1. Install and enable the plug-in.
+2. Visit a URL from your previous platform against your Vanilla installation.  For instance, if you were coming from vBulletin 4, you might visit http://site.vanillaforums.com/showthread.php?t=10001.  If all goes well, you should be directed to http://site.vanillaforums.com/discussion/10001/discussion-title/p1.
+
+## Legacy Redirects
+The Redirector plug-in supports the ability to target specific forum resources that were imported with the Forum Merge plug-in.  If you used the Forum Merge plug-in to import data from a new forum and provided a "Legacy Slug" during the merge, you can reference the original forum resource with its original ID.
+
+When two forums are merged together with Forum Merge, the record IDs from the source forum are updated to resolve conflicts with the destination forum's records.  However, if you provided a "Legacy Slug", the old IDs are combined with this slug and retained.  This allows you to reference a record from the source forum by its original ID, so long as you provide the same legacy slug as a parameter to Redirector.
+
+As an example, say you provided "vb" as the "Legacy Slug" during your merge.  One of the discussions from your source forum had the ID of 1337.  However, during the merge, that ID was reset to 10001.  You can still access that discussion with the original ID by using the following URL: http://site.vanillaforums.com/showthread.php?t=1337&legacy=vb.  If all goes well, you should be redirected to http://site.vanillaforums.com/discussion/10001/discussion-title/p1.  Without the legacy parameter set to your source forum's "Legacy Slug", you'd be taken to the forum's current discussion with an ID of 1337, which would be an entirely different discussion.
+
+## Notes
+* If you're coming from vBulletin or phpBB and experiencing issues, you may need to remove showpost.php, showthread.php and viewtopic.php from the root of your Vanilla installation directory.


### PR DESCRIPTION
Adding documentation on basic usage of Forum Merge and Redirector, as well as specifics on how to use them together to reference a source forum's IDs with the Redirector plug-in