### PR TITLE
Ensure correct appcache generation.

### DIFF
--- a/tasks/manifest.js
+++ b/tasks/manifest.js
@@ -8,6 +8,9 @@ module.exports = {
     , exclude: [
         '404.html'
       ]
+    , process: function (path) {
+        return (path === 'index.html') ? '/' : path.replace('\/index.html', '')
+      }
     }
   , src: [
       '**/index.html'


### PR DESCRIPTION
This ensures that paths in the generated appcache manifest are generated as viewed in the browser and not by their corresponding `index.html`. The latter does not appear to be valid anymore (if it ever was) and therefore breaks offline availability of the docs.