### PR TITLE
Include trailing slashes in manifest paths.

### DIFF
--- a/tasks/manifest.js
+++ b/tasks/manifest.js
@@ -9,7 +9,7 @@ module.exports = {
         '404.html'
       ]
     , process: function (path) {
-        return (path === 'index.html') ? '/' : path.replace('\/index.html', '')
+        return (path === 'index.html') ? '/' : path.replace('\/index.html', '/')
       }
     }
   , src: [


### PR DESCRIPTION
In #44 I did not anticipate that GH Pages redirects from `path` to `path/` which ended up wrecking the manifest completely.